### PR TITLE
chore: update Proxmox app icon to v2 (light.svg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Proxmox app icon to `https://s.giantswarm.io/app-icons/proxmox/2/light.svg`.
+
 ## [0.4.0] - 2026-04-20
 
 ### Added

--- a/helm/cluster-api-provider-proxmox/Chart.yaml
+++ b/helm/cluster-api-provider-proxmox/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.4.0
 name: cluster-api-provider-proxmox
 description: The Proxmox Cluster API provider
 home: https://github.com/giantswarm/cluster-api-provider-proxmox-app
-icon: https://s.giantswarm.io/app-icons/proxmox/1/dark.png
+icon: https://s.giantswarm.io/app-icons/proxmox/2/light.svg
 annotations:
   io.giantswarm.application.audience: "giantswarm"
   io.giantswarm.application.managed: "true"

--- a/sync/patches/chart/manifests/Chart.yaml
+++ b/sync/patches/chart/manifests/Chart.yaml
@@ -6,7 +6,7 @@ version: CHART_VERSION_PLACEHOLDER
 name: cluster-api-provider-proxmox
 description: The Proxmox Cluster API provider
 home: https://github.com/giantswarm/cluster-api-provider-proxmox-app
-icon: https://s.giantswarm.io/app-icons/proxmox/1/dark.png
+icon: https://s.giantswarm.io/app-icons/proxmox/2/light.svg
 annotations:
   io.giantswarm.application.audience: "giantswarm"
   io.giantswarm.application.managed: "true"


### PR DESCRIPTION
Updates the Proxmox app icon to the new shared web-asset:

`https://s.giantswarm.io/app-icons/proxmox/2/light.svg`

The sync-patch source is updated as well, so the change survives the next upstream chart sync.

> [!IMPORTANT]
> The new icon file only becomes available once [`web-assets`](https://github.com/giantswarm/web-assets) `v0.32.0` is released and rolled out. Please do not merge before then.

Context: giantswarm/giantswarm#36874
